### PR TITLE
Enable CORS in Production

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -50,6 +50,7 @@ module.exports = function(environment) {
 
   if (environment === 'production') {
     // here you can enable a production-specific feature
+    ENV.API_HOST = 'https://ember-help-wanted-server.herokuapp.com/';
   }
 
   return ENV;


### PR DESCRIPTION
Locally, the environment config will allow the app to use the local http proxy to the backend. In production, with this change, it should use the deployed heroku app.

Corresponding backend PR: https://github.com/ember-learn/ember-help-wanted-server/pull/3