### PR TITLE
Remove un used test helper

### DIFF
--- a/tests/helpers/destroy-app.js
+++ b/tests/helpers/destroy-app.js
@@ -1,8 +1,0 @@
-import { run } from '@ember/runloop';
-
-export default function destroyApp(application) {
-  run(application, 'destroy');
-  if (window.server) {
-    window.server.shutdown();
-  }
-}


### PR DESCRIPTION
This PR removes `test/helpers/destroy-app.js` which isn't used anymore. This helper was used on with the old syntax API.