### PR TITLE
Fix overlapping elements in mobile view

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -61,6 +61,17 @@
     display: flex;
     margin: 15px;
   }
+  thead {
+    display: none;
+  }
+  thead th:nth-child(1) {
+    width: 100vw;
+  }
+  td {
+    display: block;
+    width: 90vw;
+    padding: 5vw;
+  }
 }
 @media only screen and (min-width: 900px) {
   #ember258 {


### PR DESCRIPTION
 - Addressing Issue #101
 - Change td's to block display at mobile sizes
 - Adjust td padding to work with block display
 - Hide table headers at mobile sizes
 - Change table header width at mobile sizes to keep mouse-over highlight from breaking