### PR TITLE
adds temporary fix for mobile view of nav menu

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -166,4 +166,10 @@
   margin: 20px;
 }
 
-
+//temporary fix for mobile menu - remove this when ember-styleguide navbar is used.
+.mobile-menu__tray a {
+  border-bottom: 1px solid lightgray;
+  display: block;
+  padding: 1em 0.5em;
+  text-align:center;
+}


### PR DESCRIPTION
Right now all of the nav items run together in one line on a mobile device. While there is an issue to replace the navbar with the one from ember-styleguide, this code implements a temporary fix that makes the mobile navigation usable.