### PR TITLE
Replacing mobile friendly table styles removed by #113

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -112,3 +112,15 @@
   padding: 1em 0.5em;
   text-align:center;
 }
+
+//Table display for mobile view
+@media only screen and (max-width: 900px) {
+  thead {
+    display: none;
+  }
+  td {
+    display: block;
+    width: 90vw;
+    padding: 5vw;
+  }
+}


### PR DESCRIPTION
#113 Removed some navbar styles that were no longer needed. I think the mobile table display styles were accidentally removed along with them. This PR adds them back in.