### PR TITLE
#112 Ensure that issues are displaying properly when filtered by label

### DIFF
--- a/app/services/github-issues.js
+++ b/app/services/github-issues.js
@@ -19,7 +19,9 @@ let core = [
 
 let learning = [
   { repo: 'ember-learn/ember-styleguide', labels: 'help wanted :sos:' },
-  { repo: 'ember-learn/guides-source', labels: 'help wanted' }
+  { repo: 'ember-learn/guides-source', labels: 'help wanted' },
+  { repo: 'ember-learn/ember-api-docs', labels: 'help wanted' },
+  { repo: 'ember-learn/ember-website', labels: 'help wanted' }
 ];
 
 let community = [


### PR DESCRIPTION
https://github.com/ember-learn/ember-help-wanted/issues/112
Currently user can see only 11 issues for `help-wanted` label in styleguide and ember-guide repo. I've added another two repos `ember-api-docs` and `ember-website` and now it shows 29 results in second image below.
![screen shot 2019-01-27 at 6 54 39 am](https://user-images.githubusercontent.com/3090884/51794834-79c7ea80-2200-11e9-8518-88bb8c1ec33e.png)

![screen shot 2019-01-27 at 6 54 51 am](https://user-images.githubusercontent.com/3090884/51794833-792f5400-2200-11e9-8c60-95a1b703b2a5.png)
