### PR TITLE
Filter github repos with issues with help wanted labels

### DIFF
--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -3,11 +3,9 @@ import Route from '@ember/routing/route';
 export default Route.extend({
 
   model() {
-    fetch('https://api.github.com/search/repositories?q=user:ember-learn+help-wanted-issues:%3E0+archived:false').then((response) => {
-      response.json().then((repos) => {
-        this.store.pushPayload('github-repository', { githubRepository: repos.items });
-      });
-    });
+    fetch('https://api.github.com/search/repositories?q=user:ember-learn+help-wanted-issues:%3E0+archived:false')
+      .then((response) => response.json())
+      .then((repos) => this.store.pushPayload('github-repository', { githubRepository: repos.items }));
     return this.store.peekAll('github-repository');
   }
 

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -3,7 +3,14 @@ import Route from '@ember/routing/route';
 export default Route.extend({
 
   model() {
-    return this.get('store').query('github-repository', { user: 'ember-learn', type: 'all' });
+    return fetch('https://api.github.com/search/repositories?q=user:ember-learn+help-wanted-issues:%3E0+archived:false+&type=Repositories').then(function(response) {
+      return response.json().then(function(repos) {
+        repos.items.forEach((repo) => {
+          repo.displayName = repo.full_name.split('/')[1];
+        });
+        return repos.items;
+      });
+    });
   }
 
 });

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -3,14 +3,12 @@ import Route from '@ember/routing/route';
 export default Route.extend({
 
   model() {
-    return fetch('https://api.github.com/search/repositories?q=user:ember-learn+help-wanted-issues:%3E0+archived:false+&type=Repositories').then(function(response) {
-      return response.json().then(function(repos) {
-        repos.items.forEach((repo) => {
-          repo.displayName = repo.full_name.split('/')[1];
-        });
-        return repos.items;
+    fetch('https://api.github.com/search/repositories?q=user:ember-learn+help-wanted-issues:%3E0+archived:false+&type=Repositories').then((response) => {
+      response.json().then((repos) => {
+        this.store.pushPayload('github-repository', { githubRepository: repos.items });
       });
     });
+    return this.store.peekAll('github-repository');
   }
 
 });

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -3,7 +3,7 @@ import Route from '@ember/routing/route';
 export default Route.extend({
 
   model() {
-    fetch('https://api.github.com/search/repositories?q=user:ember-learn+help-wanted-issues:%3E0+archived:false&type=Repositories').then((response) => {
+    fetch('https://api.github.com/search/repositories?q=user:ember-learn+help-wanted-issues:%3E0+archived:false').then((response) => {
       response.json().then((repos) => {
         this.store.pushPayload('github-repository', { githubRepository: repos.items });
       });

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -3,7 +3,7 @@ import Route from '@ember/routing/route';
 export default Route.extend({
 
   model() {
-    fetch('https://api.github.com/search/repositories?q=user:ember-learn+help-wanted-issues:%3E0+archived:false+&type=Repositories').then((response) => {
+    fetch('https://api.github.com/search/repositories?q=user:ember-learn+help-wanted-issues:%3E0+archived:false&type=Repositories').then((response) => {
       response.json().then((repos) => {
         this.store.pushPayload('github-repository', { githubRepository: repos.items });
       });

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -14,26 +14,24 @@
 				{{/es-heading}}
 	    		<div class="row">
 	    		{{#each model as | repo |}}
-	    			{{#if (eq repo.archived "false")}}
 		    			<div class="col-sm-3 tile d-flex flex-column">
 		    				<div class="">{{repo.displayName}}</div><br>
 		    				<div class="">Forks: {{#if (not repo.forks)}} No forks {{else}} {{repo.forks}} {{/if}}</div>
 		    				<div class="linkbutton">
-		    					<a href={{repo.htmlUrl}} target="_blank">
+		    					<a href={{repo.html_url}} target="_blank">
 		    							Take me there
 			    				</a>
 		    				</div>
 		    			</div>
-						{{/if}}
 	    		{{/each}}
 		    	</div>
     	</div>
     	<div class="article container">
     		<h2>Improving the contributor experience</h2>
-				<p> 
+				<p>
 					This app is designed to help community members find issues in the Ember ecosystem that are requesting some extra help! The goal would be for this to work well for project nights for meetups, conferences and anyone else interested in hacking on various projects while also helping the main Ember repositories get much needed help with issues.
 				</p>
-				
+
 				<h3>Big Picture</h3>
 				<p>
 					To accomplish this, we use <a href="https://github.com/ember-learn/ember-help-wanted-server"> a Node backend</a> that receives Github webhook notifications about issues across a number of Ember projects. The backend will filter those issues and store them to act as our "pool" of potential issues that potential contributors can work on.
@@ -45,7 +43,7 @@
 					Meetup organizers (and contributor workshops at various Ember conferences) can also use this as a tool to sort through issues and pick subsets for their meetings. For example, if a Meetup group wants to help its members learn more about Ember Data, a meetup organizer could go through the existing pool of issues and cherry-pick 5-10 issues for folks to focus on for that evening that would help with that. This tool could be used as a foundation for running the Contributors Workshop that occurs each year at EmberConf.
 				</p>
 				<p>
-					Long-term, we are considering ways to make this easily findable by anyone who wants to contribute to Ember- tweeting out major new issues, or in other ways that communicate key pieces of info to the Ember community. We could potentially use it as a way of posting "maintainer wanted" messages as well. Do you have more ideas? Let us know! 
+					Long-term, we are considering ways to make this easily findable by anyone who wants to contribute to Ember- tweeting out major new issues, or in other ways that communicate key pieces of info to the Ember community. We could potentially use it as a way of posting "maintainer wanted" messages as well. Do you have more ideas? Let us know!
 				</p>
 
 				<p>Read More <a href="https://github.com/ember-learn/ember-help-wanted">here</a>.</p>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -18,7 +18,7 @@
 		    				<div class="">{{repo.displayName}}</div><br>
 		    				<div class="">Forks: {{#if (not repo.forks)}} No forks {{else}} {{repo.forks}} {{/if}}</div>
 		    				<div class="linkbutton">
-		    					<a href={{repo.html_url}} target="_blank">
+		    					<a href={{repo.htmlUrl}} target="_blank">
 		    							Take me there
 			    				</a>
 		    				</div>


### PR DESCRIPTION
Addresses #126 
- repos were being returned that did not have help-wanted issues
- repos were being returned that did not have any issues
- repos were being returned that were archived == true
- additionally, not all repos were being returned by ember-data-github (e.g. even though `all` was set as the type in the query, only 30 repos were returned when there are in fact 49 total repos)
- ember-data-github's query api for repos is tied to this native github api which does not provide the search flexibility desired
https://developer.github.com/v3/repos/#list-organization-repositories
- this fixes this by using the native GitHub search api
https://developer.github.com/v3/search/#search-repositories

@MelSumner let me know what you think when you have a moment
