### PR TITLE
Filters out builds and status board repos

### DIFF
--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -3,7 +3,7 @@ import Route from '@ember/routing/route';
 export default Route.extend({
 
   model() {
-    fetch('https://api.github.com/search/repositories?q=user:ember-learn+help-wanted-issues:%3E0+archived:false')
+    fetch('https://api.github.com/search/repositories?q=user:ember-learn+NOT+builds+NOT+statusboard+help-wanted-issues:%3E0+archived:false')
       .then((response) => response.json())
       .then((repos) => this.store.pushPayload('github-repository', { githubRepository: repos.items }));
     return this.store.peekAll('github-repository');


### PR DESCRIPTION
Fixes #130 
Fixes #131 

As an aside, I realized that this query might be better served residing on the server where it can be cached and we don't risk running up against rate limits as easily. 

I've written up #133 as an issue, and I can work on a PR for that, but this is a quick fix for the above referenced issues for now.