### PR TITLE
UX bugfix - remove All Issues button

### DIFF
--- a/app/templates/issues.hbs
+++ b/app/templates/issues.hbs
@@ -1,6 +1,5 @@
 <section class="container issues-header">
   <div class="help-wanted-links">
-    <a href="/">{{es-button label="All Issues" isTiny=true}}</a>
     {{#each this.navLinks.navLinks as |link|}}
       <a href={{link.href}}>{{es-button label=link.name isTiny=true}}</a>
     {{/each}}


### PR DESCRIPTION
As discussed in today's Learning Team meeting, this button has confusing behavior. It shows a list of repos instead of the issues themselves. With Hacktoberfest coming up soon, we should remove the button for now, and put it back when/if someone builds an index page.