### PR TITLE
Link to filtered issues

### DIFF
--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -21,7 +21,6 @@
               @href="{{repo.htmlUrl}}/issues?q=is%3Aissue+is%3Aopen+label%3A%22Help+Wanted%22+sort%3Acreate-date"
               @title={{repo.displayName}}>
               <p>Forks: {{#if (not repo.forks)}} No forks {{else}} {{repo.forks}} {{/if}}</p>
-              <p>All open issues: {{repo.openIssues}}</p>
             </EsLinkCard>
           {{/each}}
         </ul>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -18,7 +18,7 @@
           {{#each this.model as | repo |}}
             <EsLinkCard
               class="lg:col-3 bg-dark"
-              @href="{{repo.htmlUrl}}/issues?q=is%3Aissue+is%3Aopen+label%3A%22Help+Wanted%22"
+              @href="{{repo.htmlUrl}}/issues?q=is%3Aissue+is%3Aopen+label%3A%22Help+Wanted%22+sort%3Acreate-date"
               @title={{repo.displayName}}>
               <p>Forks: {{#if (not repo.forks)}} No forks {{else}} {{repo.forks}} {{/if}}</p>
               <p>All open issues: {{repo.openIssues}}</p>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -18,7 +18,7 @@
           {{#each this.model as | repo |}}
             <EsLinkCard
               class="lg:col-3 bg-dark"
-              @href={{repo.htmlUrl}}
+              @href="{{repo.htmlUrl}}/issues?q=is%3Aissue+is%3Aopen+label%3A%22Help+Wanted%22"
               @title={{repo.displayName}}>
               <p>Forks: {{#if (not repo.forks)}} No forks {{else}} {{repo.forks}} {{/if}}</p>
             </EsLinkCard>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -21,6 +21,7 @@
               @href="{{repo.htmlUrl}}/issues?q=is%3Aissue+is%3Aopen+label%3A%22Help+Wanted%22"
               @title={{repo.displayName}}>
               <p>Forks: {{#if (not repo.forks)}} No forks {{else}} {{repo.forks}} {{/if}}</p>
+              <p>All open issues: {{repo.openIssues}}</p>
             </EsLinkCard>
           {{/each}}
         </ul>


### PR DESCRIPTION
Implement the suggestion in #147 

❓ do we blindly tuck on stuff to the url from the backend, or should the full url come from the backend?

Also: IMO it might be useful to show the number of open issues. (These are the all open issues count, not just the `help-wanted` ones though.)