### PR TITLE
fix nested buttons inside navigation links

### DIFF
--- a/app/services/nav-links.js
+++ b/app/services/nav-links.js
@@ -1,7 +1,7 @@
 import Service from '@ember/service';
 
 export default Service.extend({
-  navLinks: '',
+  navLinks: undefined,
 
   init() {
     this._super(...arguments);
@@ -10,29 +10,27 @@ export default Service.extend({
 
   setupNavLinks() {
     let navlinks = [{
-      type: 'link',
-      href: '/core',
+      route: 'issues',
+      model: 'core',
       name: 'Core'
     }, {
-      type: 'link',
-      href: '/rfcs',
+      route: 'issues',
+      model: 'rfcs',
       name: 'RFCs'
     }, {
-      type: 'link',
-      href: '/learning',
+      route: 'issues',
+      model: 'learning',
       name: 'Learning'
     }, {
-      type: 'link',
-      href: '/community',
+      route: 'issues',
+      model: 'community',
       name: 'Community'
     }, {
-      type: 'link',
-      href: '/emberHelpWanted',
+      route: 'issues',
+      model: 'emberHelpWanted',
       name: 'Ember Help Wanted'
     }];
 
     this.set('navLinks', navlinks);
-
   }
-
 });

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -4,7 +4,7 @@
     <h1 class="text-hero-xl">Ember Help Wanted</h1>
     <div class="help-wanted-links">
       {{#each this.navLinks.navLinks as |link|}}
-        <a href={{link.href}}>{{es-button label=link.name isTiny=true}}</a>
+        <LinkTo class="es-button" @route={{link.route}} @model={{link.model}}>{{link.name}}</LinkTo>
       {{/each}}
     </div>
   </div>

--- a/app/templates/issues.hbs
+++ b/app/templates/issues.hbs
@@ -1,7 +1,7 @@
 <section class="container issues-header">
   <div class="help-wanted-links">
     {{#each this.navLinks.navLinks as |link|}}
-      <a href={{link.href}}>{{es-button label=link.name isTiny=true}}</a>
+      <LinkTo class="es-button" @route={{link.route}} @model={{link.model}}>{{link.name}}</LinkTo>
     {{/each}}
   </div>
   <form {{action "searchByWildcard" this.queryInput on="submit"}} class="search-box">


### PR DESCRIPTION
This PR attempts to fix ember-learn#169 

> fix nested buttons inside navigation links
> 
> - remove <button> elements coming from ember-styleguide button component
> - refactor plain <a> elements to <LinkTo> helpers
> - refactor service to have the route & model data for the <LinkTo> helper
> 
> Fixes ember-learn#169

## Screenshot
![image](https://user-images.githubusercontent.com/127994/95752458-0b45ed00-0c6e-11eb-9ba4-9bd43377b6bc.png)
