### PR TITLE
Reset the value of queryInput after selecting a different issues filter

### DIFF
--- a/app/controllers/issues.js
+++ b/app/controllers/issues.js
@@ -4,13 +4,12 @@ import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 
 export default Controller.extend({
+  navLinks: service(),
+
   queryParams: ['query', 'label'],
   query: '',
   label: '',
-
-  navLinks: service(),
-
-  queryInput: computed.reads('query'),
+  queryInput: '',  // TODO: Track this
 
   clearMessage: computed('label', function() {
     return `Clear search filter ${this.label}`;
@@ -18,6 +17,7 @@ export default Controller.extend({
 
   @action searchByWildcard(event) {
     event.preventDefault();
+
     this.set('query', this.queryInput);
   }
 });

--- a/app/routes/issues.js
+++ b/app/routes/issues.js
@@ -22,6 +22,12 @@ export default Route.extend({
     return this._findAllFromCategory(params.category);
   },
 
+  setupController(controller, model) {
+    this._super(controller, model);
+
+    controller.queryInput = '';
+  },
+
   _filter(params) {
     let issues = this.store.peekAll('github-issue');
     if (issues.length) {

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -4,7 +4,7 @@
     <h1 class="text-hero-xl">Ember Help Wanted</h1>
     <div class="help-wanted-links">
       {{#each this.navLinks.navLinks as |link|}}
-        <LinkTo class="es-button" @route={{link.route}} @model={{link.model}}>{{link.name}}</LinkTo>
+        <LinkTo class="es-button" @route={{link.route}} @model={{link.model}} @query={{hash query=""}}>{{link.name}}</LinkTo>
       {{/each}}
     </div>
   </div>

--- a/app/templates/issues.hbs
+++ b/app/templates/issues.hbs
@@ -1,7 +1,7 @@
 <section class="container issues-header">
   <div class="help-wanted-links">
     {{#each this.navLinks.navLinks as |link|}}
-      <LinkTo class="es-button" @route={{link.route}} @model={{link.model}}>{{link.name}}</LinkTo>
+      <LinkTo class="es-button" @route={{link.route}} @model={{link.model}} @query={{hash query=""}}>{{link.name}}</LinkTo>
     {{/each}}
   </div>
   <form {{on "submit" this.searchByWildcard}} class="search-box">


### PR DESCRIPTION
## Description

This pull request closes https://github.com/ember-learn/ember-help-wanted/issues/177.

I opted to clear the query parameter `query` when switching to a different route. I think this may help with returning issues as expected and with testing.