### PR TITLE
Glimmerize <GithubLabel>

### DIFF
--- a/app/components/github-label.hbs
+++ b/app/components/github-label.hbs
@@ -1,0 +1,1 @@
+<span class="github-label" style={{this.styleForLabel}}>{{label-with-emoji @label}}</span>

--- a/app/components/github-label.js
+++ b/app/components/github-label.js
@@ -1,16 +1,11 @@
-import Component from '@ember/component';
-import { computed } from '@ember/object';
+import Component from '@glimmer/component';
 import { htmlSafe } from '@ember/string';
 import invert from 'invert-color';
 
-export default Component.extend({
-  classNames: ['github-label'],
-  tagName: 'span',
-  attributeBindings: ['style'],
-
-  style: computed('labelColor', function() {
-    let labelColor = this.labelColor;
-    let color = invert(`#${labelColor}`, true);
-    return htmlSafe(`background-color: #${labelColor}; color: ${color};`);
-  })
-});
+export default class GithubLabelComponent extends Component {
+  get styleForLabel() {
+    const backgroundColor = this.args.backgroundColor;
+    const color = invert(`#${backgroundColor}`, true);
+    return htmlSafe(`background-color: #${backgroundColor}; color: ${color};`);
+  }
+}

--- a/app/templates/components/github-label.hbs
+++ b/app/templates/components/github-label.hbs
@@ -1,1 +1,0 @@
-{{label-with-emoji this.label}}

--- a/app/templates/issues.hbs
+++ b/app/templates/issues.hbs
@@ -46,7 +46,7 @@
             </p>
             {{#each issue.labels as |lb|}}
               <button class="github-label-button" {{on "click" (fn (mut this.label) lb.name)}} data-test-github-issue-filter-label type="button">
-                <GithubLabel @label={{lb.name}} @labelColor={{lb.color}} />
+                <GithubLabel @label={{lb.name}} @backgroundColor={{lb.color}} />
               </button>
             {{/each}}
             <br>

--- a/tests/integration/components/github-label-test.js
+++ b/tests/integration/components/github-label-test.js
@@ -1,21 +1,33 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { find, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | github-label', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('label is rendered with a text color opposite to the background color', async function(assert) {
-
+  test('label is rendered with provided @label', async function(assert) {
     await render(hbs`
-      {{github-label label="Help Wanted" labelColor="000000"}}
+      <GithubLabel @label="Help Wanted" @backgroundColor="000000" />
     `);
     assert.equal(this.element.textContent.trim(), 'Help Wanted');
+  });
+
+  test('label is rendered with provided @backgroundColor', async function(assert) {
+    await render(hbs`
+      <GithubLabel @label="Help Wanted" @backgroundColor="000000" />
+    `);
+    assert.equal(find('.github-label').style.backgroundColor, 'rgb(0, 0, 0)');
+  });
+
+  test('label is rendered with a text color opposite to the provided @backgroundColor', async function(assert) {
+    await render(hbs`
+      <GithubLabel @label="Help Wanted" @backgroundColor="000000" />
+    `);
     assert.equal(find('.github-label').style.color, 'rgb(255, 255, 255)');
 
     await render(hbs`
-      {{github-label label="Help Wanted" labelColor="FFFFFF"}}
+      <GithubLabel @label="Help Wanted" @backgroundColor="FFFFFF" />
     `);
     assert.equal(find('.github-label').style.color, 'rgb(0, 0, 0)');
   });


### PR DESCRIPTION
This PR attempts to close #175.

- Refactors classic component into a glimmer component
- Uses component template colocation
- Refactors integration tests to use the latest syntax and splits them into individual tests per functionality