### PR TITLE
docs: add Github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,11 @@
+### Expected Behavior
+
+> {expected}
+
+### Actual Behavior
+
+> {atual}
+
+### Steps to Reproduce the Problem
+
+> {steps}

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+### What does this PR do?
+
+> {description}
+
+### Which issues does this PR fix or reference?
+
+> {issues}
+
+### Proof of work
+
+> e.g. screenshot
+
+### PR Checklist
+
+As the author of this Pull Request I made sure that:
+
+- [ ] I've added unit and/or integration tests if any code was added
+- [ ] I've checked for errors using "yarn test"


### PR DESCRIPTION
### What does this PR do?

It adds a template for new issues and prs. It should be ok to not have a template for contributing, because the README seems to be already clear enough. 

This is also useful to start a discussion about the need and/or format of these files. 

### Which issues does this PR fix or reference?

--

### Proof of work

This pr itself.

### PR Checklist

As the author of this Pull Request I made sure that:

- [ ] I've added unit and/or integration tests if any code was added
- [ ] I've checked for errors using "yarn test"
