### PR TITLE
Add a missing page title for the issues route

### DIFF
--- a/app/templates/issues.hbs
+++ b/app/templates/issues.hbs
@@ -1,3 +1,4 @@
+{{page-title "Issues"}}
 <section class="container" local-class="header-container">
   <FilterMenu />
 


### PR DESCRIPTION
This page title helper was missing. The route predates the helper being included in Ember.