### PR TITLE
Remove outage triage

### DIFF
--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -5,7 +5,6 @@ export default class IndexRoute extends Route {
   @service store;
 
   model() {
-    return;
     return this.store.findAll('github-repository');
   }
 }

--- a/app/routes/issues.js
+++ b/app/routes/issues.js
@@ -18,8 +18,6 @@ export default class IssuesRoute extends Route {
   async model(params) {
     const { category, label, query } = params;
 
-    return
-
     const issues = await this.findIssues(category);
     const hasFilters = Boolean(label) || Boolean(query);
 

--- a/app/routes/pull-requests.js
+++ b/app/routes/pull-requests.js
@@ -4,7 +4,6 @@ import ENV from 'ember-help-wanted/config/environment';
 
 export default class PullRequestsRoute extends Route {
   async model() {
-    return;
     let res = await fetch(ENV.API_HOST + '/api/pull-requests');
     let prs = await res.json();
     // remove WIP Pull Requests

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -2,14 +2,8 @@
 
 <EsHeader />
 
-<main class="layout">
-  <div class="m-4">
-    Sorry for the inconvenience. This app is temporarily down for maintenance.
-    If you want to help fix it, please comment on the
-    <a href="https://github.com/ember-learn/ember-help-wanted/issues/244">
-      Github issue
-    </a>. Thank you!
-  </div>
+<main>
+  {{outlet}}
 </main>
 
 <EsFooter />


### PR DESCRIPTION
This reverts commit aa1fb31e0c9931071714915c845452fb4fe2215f which was instituted to triage an outage in the ember-help-wanted-server. 

The cause of the outage was a Github personal access token that doesn't have the required permissions any longer. The token was replaced.